### PR TITLE
Tower death animation

### DIFF
--- a/towers/archer.js
+++ b/towers/archer.js
@@ -10,7 +10,7 @@ class Archer extends Tower{
 		this.frameY = 0; 
 		this.minFrame = 0;
 		this.maxFrame = 1;
-		this.spriteWidth = 31.8;
+		this.spriteWidth = 32;
 		this.spriteHeight = 34;
 		this.idleRate = 20; // time between animation frames while idle
 		this.animationRate = this.idleRate; // time between animation frames
@@ -40,6 +40,24 @@ class Archer extends Tower{
 					projectiles.push(new Arrow(this.x + 50, this.y + 80));
 					this.frameX = this.minFrame;
 				}
+		}
+		// Cycle through death animation
+		else if(this.dying){
+			this.minFrame = 8;
+			this.maxFrame = 8;
+			
+			//start death animation immediately
+			if (this.frameX < this.minFrame){
+				this.frameX = this.minFrame;
+			}
+
+			//Use timer to determine when set Archer to dead
+			//Using timer here because only one frame is used for Archer's death 
+			this.timer++;
+			if(this.timer % 60 === 0){
+				this.dead = true;
+			}			
+			
 		}
 		// Return to idle animation when not shooting
 		else{ 

--- a/towers/dragon.js
+++ b/towers/dragon.js
@@ -43,6 +43,24 @@ class Dragon extends Tower{
 				this.frameX = this.minFrame;
 			}
 		}
+		// Cycle through death animation
+		else if(this.dying){
+			this.minFrame = 8;
+			this.maxFrame = 12;
+			
+			//start death animation immediately
+			if (this.frameX < this.minFrame){
+				this.frameX = this.minFrame;
+			}
+
+			this.animationRate = this.idleRate;
+
+			//Set dead to true when end of death animation is reached
+			if( this.frameX == this.maxFrame){
+				this.dead = true;
+			}
+			
+		}
 		// Return to idle animation when not shooting
 		else{ 
 				this.minFrame = 0;

--- a/towers/tower-utilities.js
+++ b/towers/tower-utilities.js
@@ -34,8 +34,8 @@ function updateTowers(){
 	for(let i = 0; i < towers.length; i++){
 		towers[i].draw();
 		towers[i].update();
-		// Disable Tower when no Enemies
-		if(enemyPositions.indexOf(towers[i].y) !== -1){
+		// Disable Tower when no Enemies (and when dying)
+		if(enemyPositions.indexOf(towers[i].y) !== -1 && !towers[i].dying){
 			towers[i].shooting = true;
 		}else{
 			towers[i].shooting = false;
@@ -45,22 +45,32 @@ function updateTowers(){
 			if (towers[i] && collision(towers[i], enemies[j])){
 				enemies[j].movement = 0;
 
-				// Damage dealt varies by enemy
-				if (enemies[j] instanceof Goblin){
-					towers[i].health -= 0.2; 
+				//Only deal damage to living towers
+				if (towers[i].health > 0){
+					// Damage dealt varies by enemy
+					if (enemies[j] instanceof Goblin){
+						towers[i].health -= 0.2; 
+					}
+					else if (enemies[j] instanceof Vampire){
+						towers[i].health -= 0.4; 
+					}
+					else if (enemies[j] instanceof Troll){
+						towers[i].health -= 0.8; 
+					}
 				}
-				else if (enemies[j] instanceof Vampire){
-					towers[i].health -= 0.4; 
-				}
-				else if (enemies[j] instanceof Troll){
-					towers[i].health -= 0.8; 
-				}
+				
 			}
-			// Handle Tower Death 
+			// Handle Tower Death  
+			//Trigger dying state (death animation)
 			if (towers[i] && towers[i].health <= 0){
+				towers[i].dying = true;
+				towers[i].shooting = false;
+				enemies[j].movement = enemies[j].speed;
+			}
+			//Finally remove defeated tower from the towers array
+			if (towers[i] && towers[i].dead){
 				towers.splice(i, 1);
 				i--;
-				enemies[j].movement = enemies[j].speed;
 			}
 		}
 	}

--- a/towers/towers.js
+++ b/towers/towers.js
@@ -13,8 +13,10 @@ class Tower{
 		this.shooting = false;
 		this.health = health;
 		this.timer = timer;
-		this.fireSpeed = fireSpeed;  // time between animation frames when shooting
+		this.fireSpeed = fireSpeed;  // time between animation frames when shooting 
 		this.towerSelector = towerSelector;
+		this.dying = false;
+		this.dead = false;
 	}
 	// Draw Tower on board
 	draw(textColor){

--- a/towers/wizard.js
+++ b/towers/wizard.js
@@ -43,6 +43,24 @@ class Wizard extends Tower{
 				this.frameX = this.minFrame;
 			}
 		}
+		// Cycle through death animation
+		else if(this.dying){
+			this.minFrame = 10;
+			this.maxFrame = 14;
+			
+			//start death animation immediately
+			if (this.frameX < this.minFrame){
+				this.frameX = this.minFrame;
+			}
+
+			this.animationRate = this.idleRate;
+
+			//Set dead to true when end of death animation is reached
+			if( this.frameX == this.maxFrame){
+				this.dead = true;
+			}
+			
+		}
 		// Return to idle animation when not shooting
 		else{ 
 				this.minFrame = 0;

--- a/utilities.js
+++ b/utilities.js
@@ -189,13 +189,13 @@ class TowerButton{
 			context.drawImage(this.sprite, 0, 0, 32, 34, this.x + 15, this.y + 15, 85*0.7, this.height*0.7);
 			plainText('Archer', this.x+90, this.y+20, '20px', 'black');
 			plainText( 'Cost: ' + towerCost.toString() + 'g', this.x+90, this.y+40,'12px', 'black');
-			plainText( 'HP: ' + Wizard.staticHealth.toString(), this.x+90, this.y+55,'12px', 'black');
+			plainText( 'HP: ' + Archer.staticHealth.toString(), this.x+90, this.y+55,'12px', 'black');
 		}
 		else if(this.sprite == dragonImage){
 			context.drawImage(this.sprite, 0, 0, 82, 82, this.x-20, this.y-20, 85*1.5, this.height*1.5);
 			plainText('Dragon', this.x+90, this.y+20, '20px', 'black');
 			plainText( 'Cost: ' + towerCost.toString() + 'g', this.x+90, this.y+40,'12px', 'black');
-			plainText( 'HP: ' + Wizard.staticHealth.toString(), this.x+90, this.y+55,'12px', 'black');
+			plainText( 'HP: ' + Dragon.staticHealth.toString(), this.x+90, this.y+55,'12px', 'black');
 			plainText( 'Effect: Burn', this.x+90, this.y+70,'12px', 'black');
 		}
 		else if(this.sprite == wizardImage){


### PR DESCRIPTION
Added death animations for all towers

Added 'death' and 'dying' properties to the tower class. 
This allowed me to animate the death of the tower before removing the sprite from the screen.
When the dying animation is triggered any enemies stopped by the tower should continue movement.

Dragon and Wizard towers death animation is made of multiple frames and the last frame is checked for to remove the tower from the towers array.

The Archer tower uses the timer property to check how long to leave the sprite on screen because the archer sprite only had one frame for a death animation.